### PR TITLE
Improve: browser friendliness (size)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var urlResolve = require('url').resolve;
+var urlResolve = require('resolve-pathname');
 
 // _urlJoin joins two urls
 // By resolving a url relative to the root url
@@ -6,10 +6,10 @@ var urlResolve = require('url').resolve;
 function _urlJoin(rootUrl, url) {
     // Normalize then resolve URLs
     return urlResolve(
-        // Ensure trailing slash
-        (rootUrl || '').replace(/\/+$/, '') + '/',
         // Trim preceding slash
-        (url || '').replace(/^\/+/, '')
+        (url || '').replace(/^\/+/, ''),
+        // Ensure trailing slash
+        (rootUrl || '').replace(/\/+$/, '') + '/'
     );
 }
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var urlResolve = require('resolve-pathname');
+var urlSplit = require('./urlsplit');
 
 // _urlJoin joins two urls
 // By resolving a url relative to the root url
@@ -16,11 +17,16 @@ function _urlJoin(rootUrl, url) {
 // urlJoin joins all arguments as URLs
 function urlJoin() {
     var args = Array.prototype.slice.call(arguments, 0);
-    return args.slice(1)
+
+    var baseUrl = args[0] || '/';
+    var parts = urlSplit(baseUrl);
+
+    var joinedPath = args.slice(1)
     .reduce(function(accu, x) {
         return _urlJoin(accu, x);
-    }, args[0] || '/');
+    }, parts.path || '/');
 
+    return _urlJoin(parts.domain, joinedPath);
 }
 
 module.exports = urlJoin;

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "homepage": "https://github.com/GitbookIO/urljoin.js#readme",
   "devDependencies": {
     "mocha": "^2.2.5"
+  },
+  "dependencies": {
+    "resolve-pathname": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha --reporter list",
-    "measure-size": "browserify --node index.js | uglifyjs | wc -c"
+    "measure-size": "browserify --standalone pkg index.js | uglifyjs | wc -c"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "An intuitive and robust module for joining URLs",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --reporter list"
+    "test": "mocha --reporter list",
+    "measure-size": "browserify --node index.js | uglifyjs | wc -c"
   },
   "repository": {
     "type": "git",
@@ -25,7 +26,9 @@
   },
   "homepage": "https://github.com/GitbookIO/urljoin.js#readme",
   "devDependencies": {
-    "mocha": "^2.2.5"
+    "browserify": "^14.3.0",
+    "mocha": "^2.2.5",
+    "uglify-js": "^3.0.1"
   },
   "dependencies": {
     "resolve-pathname": "^2.1.0"

--- a/test/test.js
+++ b/test/test.js
@@ -57,6 +57,12 @@ describe('urljoin.js', function() {
             'http://abc.com/about'
         );
 
+        // Ensure we can't go "below a domain"
+        assert.equal(
+            urljoin('http://abc.com/forums/', '../../about'),
+            'http://abc.com/about'
+        );
+
         assert.equal(
             urljoin('/git/', '../about'),
             '/about'

--- a/test/urlsplit.js
+++ b/test/urlsplit.js
@@ -1,0 +1,52 @@
+var assert = require('assert');
+var urlsplit = require('../urlsplit');
+
+describe('urlsplit.js', function() {
+    it('handle hosts', function() {
+        assert.deepEqual(
+            urlsplit('http://abc.com/git/'),
+            {domain: 'http://abc.com', path: '/git/'}
+        );
+
+        assert.deepEqual(
+            urlsplit('http://abc.com'),
+            {domain: 'http://abc.com', path: ''}
+        );
+
+        assert.deepEqual(
+            urlsplit('http://abc.com/'),
+            {domain: 'http://abc.com', path: '/'}
+        );
+
+        assert.deepEqual(
+            urlsplit('https://abc.com/about'),
+            {domain: 'https://abc.com', path: '/about'}
+        );
+    });
+
+    it('handle query strings', function() {
+        assert.deepEqual(
+            urlsplit('/abc/index.php?a=b'),
+            {domain: '', path: '/abc/index.php?a=b'}
+        );
+    });
+
+    it('handle empty url', function() {
+        // Map to dot like path.join
+        assert.deepEqual(
+            urlsplit(''),
+            {domain: '', path: ''}
+        );
+    });
+
+    it('handle paths (no hostname)', function() {
+        assert.deepEqual(
+            urlsplit('/Users/aaron/git'),
+            {domain: '', path: '/Users/aaron/git'}
+        );
+        assert.deepEqual(
+            urlsplit('/'),
+            {domain: '', path: '/'}
+        );
+    })
+});

--- a/urlsplit.js
+++ b/urlsplit.js
@@ -1,0 +1,28 @@
+// urlSplit splits a url into [`proto://domain` and `/path`]
+function urlSplit(url) {
+    var protoIdx = url.indexOf('://');
+    // Plain path
+    if(protoIdx === -1) {
+        return {
+            domain: '',
+            path: url,
+        };
+    }
+
+    var slashIdx = url.indexOf('/', protoIdx+3);
+    // No slash, so plain domain
+    if(slashIdx === -1) {
+        return {
+            domain: url,
+            path: '',
+        };
+    }
+
+    // Split path
+    return {
+        domain: url.slice(0, slashIdx),
+        path: url.slice(slashIdx)
+    };
+}
+
+module.exports = urlSplit;


### PR DESCRIPTION
Reduce overall bundle size for the browser

## Before

```
❯ npm run measure-size

> urljoin.js@0.1.0 measure-size /Users/aaron/git/urljoin.js
> browserify --standalone pkg index.js | uglifyjs | wc -c

   20753
```

## After

```
❯ npm run measure-size

> urljoin.js@0.1.0 measure-size /Users/aaron/git/urljoin.js
> browserify --standalone pkg index.js | uglifyjs | wc -c

    3030
```